### PR TITLE
Fix menu width for firefox

### DIFF
--- a/frontend/src/styles/settings.scss
+++ b/frontend/src/styles/settings.scss
@@ -20,6 +20,13 @@ body {
     scrollbar-width: thin;
 }
 
+/* Fix meny width for fierfox */
+@supports (-moz-appearance:none) {
+    .v-list {
+        width: 130%;
+    }
+}
+
 /*
 ::-webkit-scrollbar {
     width: 8px;


### PR DESCRIPTION
Fix meny width for Fierfox.

Before on FireFox
![bild](https://github.com/user-attachments/assets/3eaa458d-a01d-4e93-8ad1-26bb5d5a1cd1)
After on FireFox
![bild](https://github.com/user-attachments/assets/bb54022f-c5b2-4eb7-a33e-3d39a03dd6e0)

It should only change on fierfox from testing on own clone